### PR TITLE
Adding Xcode 5 GM UUIDs to all fixins.

### DIFF
--- a/XCFixin_CurrentLineHighlighter/Info.plist
+++ b/XCFixin_CurrentLineHighlighter/Info.plist
@@ -22,6 +22,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
+	</array>
 	<key>NSPrincipalClass</key>
 	<string>XCFixin_CurrentLineHighlighter</string>
 	<key>XC4Compatible</key>

--- a/XCFixin_CustomizeWarningErrorHighlights/Info.plist
+++ b/XCFixin_CustomizeWarningErrorHighlights/Info.plist
@@ -22,6 +22,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
+	</array>
 	<key>NSPrincipalClass</key>
 	<string>XCFixin_CustomizeWarningErrorHighlights</string>
 	<key>XC4Compatible</key>

--- a/XCFixin_DisableAnimations/Info.plist
+++ b/XCFixin_DisableAnimations/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
+	<key>CFBundleDisplayName</key>
+	<string></string>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIconFile</key>
@@ -22,6 +24,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
+	</array>
 	<key>NSPrincipalClass</key>
 	<string>XCFixin_DisableAnimations</string>
 	<key>XC4Compatible</key>

--- a/XCFixin_FindFix/Info.plist
+++ b/XCFixin_FindFix/Info.plist
@@ -22,6 +22,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
+	</array>
 	<key>NSPrincipalClass</key>
 	<string>XCFixin_FindFix</string>
 	<key>XC4Compatible</key>

--- a/XCFixin_HideDistractions/Info.plist
+++ b/XCFixin_HideDistractions/Info.plist
@@ -22,6 +22,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
+	</array>
 	<key>NSPrincipalClass</key>
 	<string>XCFixin_HideDistractions</string>
 	<key>XC4Compatible</key>

--- a/XCFixin_InhibitTabNextPlaceholder/Info.plist
+++ b/XCFixin_InhibitTabNextPlaceholder/Info.plist
@@ -22,6 +22,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
+	</array>
 	<key>NSPrincipalClass</key>
 	<string>XCFixin_InhibitTabNextPlaceholder</string>
 	<key>XC4Compatible</key>

--- a/XCFixin_TabAcceptsCompletions/Info.plist
+++ b/XCFixin_TabAcceptsCompletions/Info.plist
@@ -22,6 +22,10 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
+	</array>
 	<key>NSPrincipalClass</key>
 	<string>XCFixin_TabAcceptsCompletions</string>
 	<key>XC4Compatible</key>

--- a/XCFixin_UserScripts/Info.plist
+++ b/XCFixin_UserScripts/Info.plist
@@ -22,13 +22,17 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>DVTPlugInCompatibilityUUIDs</key>
+	<array>
+		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
+	</array>
+	<key>NSPrincipalClass</key>
+	<string>XCFixin_UserScripts</string>
 	<key>XC4Compatible</key>
 	<true/>
 	<key>XCGCReady</key>
 	<true/>
 	<key>XCPluginHasUI</key>
 	<false/>
-	<key>NSPrincipalClass</key>
-	<string>XCFixin_UserScripts</string>
 </dict>
 </plist>


### PR DESCRIPTION
I've added the Xcode 5 compatibility UUID to all fixin Info.plist files. This adds support for Xcode 5 GM! (Let me know if you'd like anything else from my pull request; I'm happy to oblige.)
